### PR TITLE
Include headers and modulemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ To create a new release for this project follow these steps:
 - If you'd like a fat binary for supporting arm64 and x86_64 macs, build
   with `./swift/utils/build-script --release --cross-compile-hosts
   macosx-x86_64`
-- Run `create-xcframework.sh binary1 binary2` to create the combined
-  framework
+- Run `create-xcframework.sh swift/src/dir binary1 binary2` to create
+  the combined framework
 
 ## Notes
 

--- a/create-xcframework.sh
+++ b/create-xcframework.sh
@@ -3,8 +3,19 @@
 set -euo pipefail
 set -x
 
-if [[ $# -ne 2 ]]; then
-  echo "Usage: $0 path/to/arm64 path/to/x86_64"
+if [[ $# -ne 3 ]]; then
+  echo "Usage: $0 path/to/swift/checkout path/to/arm64 path/to/x86_64"
+  exit 1
+fi
+
+include_dir=$1/swift/include/swift-c/SyntaxParser
+shift
+if [[ "$include_dir" != /* ]]; then
+  include_dir="$PWD/$include_dir"
+fi
+
+if [[ ! -d "$include_dir" ]]; then
+  echo "error: failed to find syntax parser include directory, please file an issue" >&2
   exit 1
 fi
 
@@ -22,7 +33,14 @@ fi
 
 workdir=$(mktemp -d)
 pushd "$workdir"
-mkdir -p lib_InternalSwiftSyntaxParser.framework
+mkdir -p lib_InternalSwiftSyntaxParser.framework/Headers lib_InternalSwiftSyntaxParser.framework/Modules
+cp "$include_dir"/*.h lib_InternalSwiftSyntaxParser.framework/Headers
+
+echo 'framework module _InternalSwiftSyntaxParser {
+  umbrella header "SwiftSyntaxParser.h"
+  export *
+  module * { export * }
+}' > lib_InternalSwiftSyntaxParser.framework/Modules/module.modulemap
 lipo -create -output lib_InternalSwiftSyntaxParser.framework/lib_InternalSwiftSyntaxParser "$binary1" "$binary2"
 xcodebuild -create-xcframework -framework lib_InternalSwiftSyntaxParser.framework -output lib_InternalSwiftSyntaxParser.xcframework
 popd


### PR DESCRIPTION
Previously we were still relying on the system toolchain's headers /
modulemap for this library which isn't valid at the point that changes
and SwiftSyntax adopts the new functionality. I first hit this trying to
build Swift 5.7's SwiftSyntax with Xcode 13.4. Theoretically things
could be entirely incompatible and it would require the new Xcode
(because of a new Swift language feature), but this is better than
nothing for these specific cases.